### PR TITLE
Refactor into multi-crate Ledger SDK workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,20 @@
 version = 4
 
 [[package]]
-name = "ledger-sdk-rust"
+name = "apdu"
 version = "0.1.0"
+
+[[package]]
+name = "eth-app"
+version = "0.1.0"
+dependencies = [
+ "apdu",
+ "transport",
+]
+
+[[package]]
+name = "transport"
+version = "0.1.0"
+dependencies = [
+ "apdu",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
-[package]
-name = "ledger-sdk-rust"
-version = "0.1.0"
-edition = "2024"
-
-[dependencies]
+[workspace]
+members = [
+    "apdu",
+    "transport",
+    "eth-app"
+]
+resolver = "2"

--- a/apdu/Cargo.toml
+++ b/apdu/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "apdu"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/apdu/src/lib.rs
+++ b/apdu/src/lib.rs
@@ -1,0 +1,31 @@
+#[derive(Debug)]
+pub struct ApduCommand {
+    pub cla: u8,
+    pub ins: u8,
+    pub p1: u8,
+    pub p2: u8,
+    pub data: Vec<u8>,
+}
+
+impl ApduCommand {
+    pub fn new(cla: u8, ins: u8, p1: u8, p2: u8, data: Vec<u8>) -> Self {
+        Self { cla, ins, p1, p2, data }
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = vec![self.cla, self.ins, self.p1, self.p2, self.data.len() as u8];
+        bytes.extend(&self.data);
+        bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_command() {
+        let cmd = ApduCommand::new(0xE0, 0x02, 0x00, 0x00, vec![1, 2, 3]);
+        assert_eq!(cmd.to_bytes(), vec![0xE0, 0x02, 0x00, 0x00, 3, 1, 2, 3]);
+    }
+}

--- a/eth-app/Cargo.toml
+++ b/eth-app/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "eth-app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+apdu = { path = "../apdu" }
+transport = { path = "../transport" }

--- a/eth-app/src/lib.rs
+++ b/eth-app/src/lib.rs
@@ -1,0 +1,30 @@
+use apdu::ApduCommand;
+use transport::Transport;
+
+pub struct EthApp<T: Transport> {
+    transport: T,
+}
+
+impl<T: Transport> EthApp<T> {
+    pub fn new(transport: T) -> Self {
+        Self { transport }
+    }
+
+    pub fn get_address(&self) -> Vec<u8> {
+        let cmd = ApduCommand::new(0xE0, 0x02, 0x00, 0x00, vec![]);
+        self.transport.exchange(&cmd)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use transport::MockTransport;
+
+    #[test]
+    fn retrieves_address() {
+        let app = EthApp::new(MockTransport);
+        let response = app.get_address();
+        assert_eq!(response, vec![0x90, 0x00]);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/transport/Cargo.toml
+++ b/transport/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "transport"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+apdu = { path = "../apdu" }

--- a/transport/src/lib.rs
+++ b/transport/src/lib.rs
@@ -1,0 +1,29 @@
+use apdu::ApduCommand;
+
+pub trait Transport {
+    fn exchange(&self, command: &ApduCommand) -> Vec<u8>;
+}
+
+pub struct MockTransport;
+
+impl Transport for MockTransport {
+    fn exchange(&self, command: &ApduCommand) -> Vec<u8> {
+        // For now just return success status word
+        let _ = command.to_bytes();
+        vec![0x90, 0x00]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use apdu::ApduCommand;
+
+    #[test]
+    fn mock_transport_returns_success() {
+        let transport = MockTransport;
+        let cmd = ApduCommand::new(0x00, 0x00, 0x00, 0x00, vec![]);
+        let resp = transport.exchange(&cmd);
+        assert_eq!(resp, vec![0x90, 0x00]);
+    }
+}


### PR DESCRIPTION
## Summary
- Organize repository as a Cargo workspace
- Add `apdu`, `transport`, and `eth-app` crates
- Implement simple data structures and examples for APDU transport and ETH app

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68c0c7a41190832093c9eb3ae942ae2e